### PR TITLE
changed from apiKey to LambdaAuthoriser

### DIFF
--- a/DeveloperHubAPI/serverless.yml
+++ b/DeveloperHubAPI/serverless.yml
@@ -10,14 +10,6 @@ provider:
   stage: ${opt:stage}
   account: ${opt:account}
   region: eu-west-2
-  apiKeys:
-    - secureAccess:
-      - api-key-${self:service}-${self:provider.stage}
-  usagePlan:
-    - secureAccess:
-        throttle:
-          burstLimit: 200
-          rateLimit: 100
 
 package:
   artifact: ./bin/release/netcoreapp3.1/developer-hub-api.zip
@@ -32,7 +24,12 @@ functions:
       - http:
           path: /{proxy+}
           method: ANY
-          private: true
+          authorizer:
+            arn: ${ssm:/api-authenticator/${self:provider.stage}/arn}
+            type: request
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
+            managedExternally: true
       - http:
           path: /swagger/{proxy+}
           method: GET


### PR DESCRIPTION
### *What is the problem we're trying to solve*

To secure the API using a Lambda Authoriser instead of an API Key, as it is a more robust form of security.

### *What changes have we introduced*

I deleted api key from serverless.yml and replaced it with Lambda Authoriser 

#### _Checklist_

- [x] Code pipeline builds correctly
