### PR TITLE
Spike endpoint auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,62 +182,62 @@ workflows:
           filters:
             branches:
               only: master
-  check-and-deploy-staging-and-production:
-      jobs:
-      - build-and-test:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              only: release
-      - assume-role-staging:
-          context: api-assume-role-staging-context
-          requires:
-              - build-and-test
-          filters:
-             branches:
-               only: release
-      - terraform-init-and-apply-to-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: release
-      - deploy-to-staging:
-          context: api-nuget-token-context
-          requires:
-            - terraform-init-and-apply-to-staging
-          filters:
-            branches:
-              only: release
-      - permit-production-terraform-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-      - assume-role-production:
-          context: api-assume-role-production-context
-          requires:
-              - permit-production-terraform-release
-          filters:
-             branches:
-               only: release
-      - terraform-init-and-apply-to-production:
-          requires:
-            - assume-role-production
-          filters:
-            branches:
-              only: release
-      - permit-production-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: release
-      - deploy-to-production:
-          context: api-nuget-token-context
-          requires:
-            - permit-production-release
-            - terraform-init-and-apply-to-production
-          filters:
-            branches:
-              only: release
+  # check-and-deploy-staging-and-production:
+  #     jobs:
+  #     - build-and-test:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - assume-role-staging:
+  #         context: api-assume-role-staging-context
+  #         requires:
+  #             - build-and-test
+  #         filters:
+  #            branches:
+  #              only: release
+  #     - terraform-init-and-apply-to-staging:
+  #         requires:
+  #           - assume-role-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - deploy-to-staging:
+  #         context: api-nuget-token-context
+  #         requires:
+  #           - terraform-init-and-apply-to-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - permit-production-terraform-release:
+  #         type: approval
+  #         requires:
+  #           - deploy-to-staging
+  #     - assume-role-production:
+  #         context: api-assume-role-production-context
+  #         requires:
+  #             - permit-production-terraform-release
+  #         filters:
+  #            branches:
+  #              only: release
+  #     - terraform-init-and-apply-to-production:
+  #         requires:
+  #           - assume-role-production
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - permit-production-release:
+  #         type: approval
+  #         requires:
+  #           - deploy-to-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - deploy-to-production:
+  #         context: api-nuget-token-context
+  #         requires:
+  #           - permit-production-release
+  #           - terraform-init-and-apply-to-production
+  #         filters:
+  #           branches:
+  #             only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,78 +166,78 @@ workflows:
           context: api-assume-role-development-context
           requires:
             - build-and-test
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
       - terraform-init-and-apply-to-development:
           requires:
             - assume-role-development
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
             - terraform-init-and-apply-to-development
+          # filters:
+          #   branches:
+          #     only: master
+  check-and-deploy-staging-and-production:
+      jobs:
+      - build-and-test:
+          context: api-nuget-token-context
           filters:
             branches:
-              only: master
-  # check-and-deploy-staging-and-production:
-  #     jobs:
-  #     - build-and-test:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - assume-role-staging:
-  #         context: api-assume-role-staging-context
-  #         requires:
-  #             - build-and-test
-  #         filters:
-  #            branches:
-  #              only: release
-  #     - terraform-init-and-apply-to-staging:
-  #         requires:
-  #           - assume-role-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - deploy-to-staging:
-  #         context: api-nuget-token-context
-  #         requires:
-  #           - terraform-init-and-apply-to-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - permit-production-terraform-release:
-  #         type: approval
-  #         requires:
-  #           - deploy-to-staging
-  #     - assume-role-production:
-  #         context: api-assume-role-production-context
-  #         requires:
-  #             - permit-production-terraform-release
-  #         filters:
-  #            branches:
-  #              only: release
-  #     - terraform-init-and-apply-to-production:
-  #         requires:
-  #           - assume-role-production
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - permit-production-release:
-  #         type: approval
-  #         requires:
-  #           - deploy-to-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - deploy-to-production:
-  #         context: api-nuget-token-context
-  #         requires:
-  #           - permit-production-release
-  #           - terraform-init-and-apply-to-production
-  #         filters:
-  #           branches:
-  #             only: release
+              only: release
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          requires:
+              - build-and-test
+          filters:
+             branches:
+               only: release
+      - terraform-init-and-apply-to-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: release
+      - deploy-to-staging:
+          context: api-nuget-token-context
+          requires:
+            - terraform-init-and-apply-to-staging
+          filters:
+            branches:
+              only: release
+      - permit-production-terraform-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+      - assume-role-production:
+          context: api-assume-role-production-context
+          requires:
+              - permit-production-terraform-release
+          filters:
+             branches:
+               only: release
+      - terraform-init-and-apply-to-production:
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              only: release
+      - permit-production-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+          filters:
+            branches:
+              only: release
+      - deploy-to-production:
+          context: api-nuget-token-context
+          requires:
+            - permit-production-release
+            - terraform-init-and-apply-to-production
+          filters:
+            branches:
+              only: release

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ tmp/
 
 .fake
 .ionide
+.vscode/

--- a/DeveloperHubAPI.Tests/DynamoDbIntegrationTests.cs
+++ b/DeveloperHubAPI.Tests/DynamoDbIntegrationTests.cs
@@ -34,7 +34,7 @@ namespace DeveloperHubAPI.Tests
 
             EnsureEnvVarConfigured("DynamoDb_LocalMode", "true");
             EnsureEnvVarConfigured("DynamoDb_LocalServiceUrl", "http://localhost:8000");
-            EnsureEnvVarConfigured("googleGroups", "e2e-testing");
+            EnsureEnvVarConfigured("ALLOWED_GOOGLE_GROUPS", "e2e-testing");
             _factory = new DynamoDbMockWebApplicationFactory<TStartup>(_tables);
             Client = _factory.CreateClient();
         }

--- a/DeveloperHubAPI.Tests/DynamoDbIntegrationTests.cs
+++ b/DeveloperHubAPI.Tests/DynamoDbIntegrationTests.cs
@@ -34,6 +34,7 @@ namespace DeveloperHubAPI.Tests
 
             EnsureEnvVarConfigured("DynamoDb_LocalMode", "true");
             EnsureEnvVarConfigured("DynamoDb_LocalServiceUrl", "http://localhost:8000");
+            EnsureEnvVarConfigured("googleGroups", "e2e-testing");
             _factory = new DynamoDbMockWebApplicationFactory<TStartup>(_tables);
             Client = _factory.CreateClient();
         }

--- a/DeveloperHubAPI.Tests/V1/Authorization/AuthorizeByGroupsTests.cs
+++ b/DeveloperHubAPI.Tests/V1/Authorization/AuthorizeByGroupsTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using AutoFixture;
+using DeveloperHubAPI.V1.Authorization;
+using FluentAssertions;
+using Hackney.Core.Http;
+using Hackney.Core.JWT;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using NUnit.Framework;
+
+namespace DeveloperHubAPI.Tests.V1.Authorization
+{
+    [TestFixture]
+    public class AuthoriseByGroupsTests
+    {
+        TokenGroupsFilter _classUnderTest;
+        Mock<IHttpContextWrapper> _mockContextWrapper;
+        Mock<ITokenFactory> _mockTokenFactory;
+        private string[] _requiredGoogleGroups;
+        private static Fixture _fixture => new Fixture();
+
+        [SetUp]
+        public void Init()
+        {
+            _mockContextWrapper = new Mock<IHttpContextWrapper>();
+            _mockTokenFactory = new Mock<ITokenFactory>();
+            _requiredGoogleGroups = new string[] { "test_group_name", "some-other-group" };
+
+            Environment.SetEnvironmentVariable("groups", string.Join(",", _requiredGoogleGroups));
+
+            _classUnderTest = new TokenGroupsFilter(_mockContextWrapper.Object, _mockTokenFactory.Object, "groups");
+        }
+
+        [Test]
+        public void ConstructorThrowsErrorIfGroupsEnvVariableIsNull()
+        {
+            var incorrectEnvVariable = "var";
+
+            Func<TokenGroupsFilter> func = () => new TokenGroupsFilter(_mockContextWrapper.Object, _mockTokenFactory.Object, incorrectEnvVariable);
+
+            func.Should().Throw<EnvironmentVariableNullException>().WithMessage($"Cannot resolve {incorrectEnvVariable} environment variable.");
+        }
+
+        private (AuthorizationFilterContext, HeaderDictionary) SetUpMockContextAndHeaders()
+        {
+            var mockHttpContext = new Mock<HttpContext>();
+            var actionContext = new ActionContext(mockHttpContext.Object,
+                                                  new Microsoft.AspNetCore.Routing.RouteData(),
+                                                  new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor());
+            var context = new AuthorizationFilterContext(actionContext, new List<IFilterMetadata>());
+
+            var requestHeaders = new HeaderDictionary(new Dictionary<string, StringValues> { { "Authorization", "abc" } });
+            _mockContextWrapper.Setup(x => x.GetContextRequestHeaders(context.HttpContext)).Returns(requestHeaders);
+
+            return (context, requestHeaders);
+        }
+
+        [Test]
+        public void OnAuthorizationResultIsUnauthorizedIfTokenIsNull()
+        {
+            // Arrange
+            (var context, var requestHeaders) = SetUpMockContextAndHeaders();
+            _mockTokenFactory.Setup(x => x.Create(requestHeaders, "Authorization")).Returns((Token) null);
+            // Act
+            _classUnderTest.OnAuthorization(context);
+            // Assert
+            context.Result.Should().BeOfType(typeof(UnauthorizedObjectResult));
+            (context.Result as UnauthorizedObjectResult).Value.Should().Be("User  is not authorized to access this endpoint.");
+            _mockTokenFactory.Verify(x => x.Create(requestHeaders, "Authorization"), Times.Once);
+        }
+
+        [Test]
+        public void OnAuthorizationResultIsUnauthorizedIfTokenDoesNotContainRequiredGoogleGroups()
+        {
+            // Arrange
+            (var context, var requestHeaders) = SetUpMockContextAndHeaders();
+            var userToken = _fixture.Build<Token>().With(x => x.Groups, new string[] { "not one of the allowed groups" }).Create();
+            _mockTokenFactory.Setup(x => x.Create(requestHeaders, "Authorization")).Returns((Token) userToken);
+            // Act
+            _classUnderTest.OnAuthorization(context);
+            // Assert
+            context.Result.Should().BeOfType(typeof(UnauthorizedObjectResult));
+            (context.Result as UnauthorizedObjectResult).Value.Should().Be($"User {userToken.Name} is not authorized to access this endpoint.");
+            _mockTokenFactory.Verify(x => x.Create(requestHeaders, "Authorization"), Times.Once);
+        }
+
+        [Test]
+        public void OnAuthorizationResultIsNullIfTokenContainsOneOfTheRequiredGoogleGroups()
+        {
+            // Arrange
+            (var context, var requestHeaders) = SetUpMockContextAndHeaders();
+            var userToken = _fixture.Build<Token>().With(x => x.Groups, new string[] { "test_group_name" }).Create();
+            _mockTokenFactory.Setup(x => x.Create(requestHeaders, "Authorization")).Returns((Token) userToken);
+            // Act
+            _classUnderTest.OnAuthorization(context);
+            // Assert
+            context.Result.Should().BeNull();
+            _mockTokenFactory.Verify(x => x.Create(requestHeaders, "Authorization"), Times.Once);
+        }
+
+    }
+}

--- a/DeveloperHubAPI.Tests/V1/E2ETests/Constants.cs
+++ b/DeveloperHubAPI.Tests/V1/E2ETests/Constants.cs
@@ -1,0 +1,9 @@
+namespace DeveloperHubAPI.Tests.V1.E2ETests.Constants
+{
+    public static class TestToken
+    {
+        public const string Value = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMTUwMTgxMTYwOTIwOTg2NzYxMTMiLCJlbWFpbCI6ImUyZS10ZXN0aW5nQGRldmVsb3BtZW50LmNvbSIsImlzcyI6IkhhY2tuZXkiLCJuYW1lIjoiVGVzdGVyIiwiZ3JvdXBzIjpbImUyZS10ZXN0aW5nIl0sImlhdCI6MTYyMzA1ODIzMn0.SooWAr-NUZLwW8brgiGpi2jZdWjyZBwp4GJikn0PvEw";
+        public const string UserName = "Tester";
+        public const string UserEmail = "e2e-testing@development.com";
+    }
+}

--- a/DeveloperHubAPI.Tests/V1/E2ETests/DeleteApplicationByName.cs
+++ b/DeveloperHubAPI.Tests/V1/E2ETests/DeleteApplicationByName.cs
@@ -35,7 +35,7 @@ namespace DeveloperHubAPI.Tests.V1.E2ETests
 
         [Test]
 
-        public async Task DeleteApplicationByNameReturns404()
+        public async Task DeleteApplicationByNameReturns404NotFound()
         {
             // Arrange
             var id = 987654321;
@@ -53,6 +53,7 @@ namespace DeveloperHubAPI.Tests.V1.E2ETests
             httpResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
             message.Dispose();
         }
+
         [Test]
         public async Task DeleteApplicationByNameDeletesTheApplication()
         {
@@ -72,6 +73,24 @@ namespace DeveloperHubAPI.Tests.V1.E2ETests
 
             // Assert
             httpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            message.Dispose();
+        }
+
+        public async Task DeleteApplicationByNameReturns401Unauthorized()
+        {
+            // Arrange
+            var id = 987654321;
+            var applicationName = "random";
+            var uri = new Uri($"api/v1/developerhubapi/{id}/{applicationName}", UriKind.Relative);
+            var bodyParameters = _fixture.Create<DeleteApplicationByNameRequest>();
+
+            // Act
+            var message = new HttpRequestMessage(HttpMethod.Delete, uri);
+            message.Content = new StringContent(JsonConvert.SerializeObject(bodyParameters), Encoding.UTF8, "application/json");
+            var httpResponse = await Client.SendAsync(message).ConfigureAwait(false);
+
+            // Assert
+            httpResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
             message.Dispose();
         }
 

--- a/DeveloperHubAPI.Tests/V1/E2ETests/DeleteApplicationByName.cs
+++ b/DeveloperHubAPI.Tests/V1/E2ETests/DeleteApplicationByName.cs
@@ -1,4 +1,6 @@
 using AutoFixture;
+using DeveloperHubAPI.Tests.V1.E2ETests.Constants;
+using DeveloperHubAPI.V1.Boundary.Request;
 using DeveloperHubAPI.V1.Boundary.Response;
 using DeveloperHubAPI.V1.Domain;
 using DeveloperHubAPI.V1.Factories;
@@ -8,6 +10,8 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
 using System.Net;
+using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace DeveloperHubAPI.Tests.V1.E2ETests
@@ -33,13 +37,21 @@ namespace DeveloperHubAPI.Tests.V1.E2ETests
 
         public async Task DeleteApplicationByNameReturns404()
         {
+            // Arrange
             var id = 987654321;
             var applicationName = "random";
             var uri = new Uri($"api/v1/developerhubapi/{id}/{applicationName}", UriKind.Relative);
+            var bodyParameters = _fixture.Create<DeleteApplicationByNameRequest>();
 
-            var response = await Client.DeleteAsync(uri).ConfigureAwait(false);
+            // Act
+            var message = new HttpRequestMessage(HttpMethod.Delete, uri);
+            message.Content = new StringContent(JsonConvert.SerializeObject(bodyParameters), Encoding.UTF8, "application/json");
+            message.Headers.Add("Authorization", TestToken.Value);
+            var httpResponse = await Client.SendAsync(message).ConfigureAwait(false);
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // Assert
+            httpResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            message.Dispose();
         }
         [Test]
         public async Task DeleteApplicationByNameDeletesTheApplication()
@@ -50,12 +62,17 @@ namespace DeveloperHubAPI.Tests.V1.E2ETests
             api.Applications.Add(application);
             await SetupTestData(api.ToDatabase()).ConfigureAwait(false);
             var uri = new Uri($"api/v1/developerhubapi/{api.Id}/{application.Name}", UriKind.Relative);
+            var bodyParameters = _fixture.Create<DeleteApplicationByNameRequest>();
 
-            //Act
-            var response = await Client.DeleteAsync(uri).ConfigureAwait(false);
+            // Act
+            var message = new HttpRequestMessage(HttpMethod.Delete, uri);
+            message.Content = new StringContent(JsonConvert.SerializeObject(bodyParameters), Encoding.UTF8, "application/json");
+            message.Headers.Add("Authorization", TestToken.Value);
+            var httpResponse = await Client.SendAsync(message).ConfigureAwait(false);
 
             // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            httpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            message.Dispose();
         }
 
     }

--- a/DeveloperHubAPI.Tests/V1/E2ETests/UpdateApplicationE2ETests.cs
+++ b/DeveloperHubAPI.Tests/V1/E2ETests/UpdateApplicationE2ETests.cs
@@ -35,7 +35,7 @@ namespace DeveloperHubAPI.Tests.V1.E2ETests
         }
 
         [Test]
-        public async Task UpdateApplicationReturns404()
+        public async Task UpdateApplicationReturns404NotFound()
         {
             // Arrange  
             var id = 123456789;
@@ -55,7 +55,7 @@ namespace DeveloperHubAPI.Tests.V1.E2ETests
         }
 
         [Test]
-        public async Task UpdateApplicationReturns204()
+        public async Task UpdateApplicationReturns204NoContent()
         {
             // Arrange  
             var bodyParameters = _fixture.Create<UpdateApplicationListItem>();
@@ -73,6 +73,25 @@ namespace DeveloperHubAPI.Tests.V1.E2ETests
             var updatedApi = await DynamoDbContext.LoadAsync<DeveloperHubDb>(api.Id).ConfigureAwait(false);
             updatedApi.Applications.LastOrDefault().Name.Should().Be(bodyParameters.Name);
             updatedApi.Applications.LastOrDefault().Link.Should().Be(bodyParameters.Link);
+            message.Dispose();
+        }
+
+        [Test]
+        public async Task UpdateApplicationReturns404Unauthorized()
+        {
+            // Arrange  
+            var id = 123456789;
+            var applicationName = "random";
+            var uri = new Uri($"api/v1/developerhubapi/{id}/{applicationName}", UriKind.Relative);
+            var bodyParameters = _fixture.Create<UpdateApplicationListItem>();
+
+            // Act
+            var message = new HttpRequestMessage(HttpMethod.Patch, uri);
+            message.Content = new StringContent(JsonConvert.SerializeObject(bodyParameters), Encoding.UTF8, "application/json");
+            var response = await Client.SendAsync(message).ConfigureAwait(false);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
             message.Dispose();
         }
     }

--- a/DeveloperHubAPI.Tests/V1/E2ETests/UpdateApplicationE2ETests.cs
+++ b/DeveloperHubAPI.Tests/V1/E2ETests/UpdateApplicationE2ETests.cs
@@ -1,4 +1,5 @@
 using AutoFixture;
+using DeveloperHubAPI.Tests.V1.E2ETests.Constants;
 using DeveloperHubAPI.V1.Boundary.Request;
 using DeveloperHubAPI.V1.Boundary.Response;
 using DeveloperHubAPI.V1.Domain;
@@ -45,6 +46,7 @@ namespace DeveloperHubAPI.Tests.V1.E2ETests
             // Act
             var message = new HttpRequestMessage(HttpMethod.Patch, uri);
             message.Content = new StringContent(JsonConvert.SerializeObject(bodyParameters), Encoding.UTF8, "application/json");
+            message.Headers.Add("Authorization", TestToken.Value);
             var response = await Client.SendAsync(message).ConfigureAwait(false);
 
             // Assert
@@ -63,6 +65,7 @@ namespace DeveloperHubAPI.Tests.V1.E2ETests
             // Act
             var message = new HttpRequestMessage(HttpMethod.Patch, uri);
             message.Content = new StringContent(JsonConvert.SerializeObject(bodyParameters), Encoding.UTF8, "application/json");
+            message.Headers.Add("Authorization", TestToken.Value);
             var response = await Client.SendAsync(message).ConfigureAwait(false);
 
             // Assert

--- a/DeveloperHubAPI/V1/Authorization/AuthorizeByGroups.cs
+++ b/DeveloperHubAPI/V1/Authorization/AuthorizeByGroups.cs
@@ -35,7 +35,7 @@ namespace DeveloperHubAPI.V1.Authorization
             _tokenFactory = tokenFactory;
 
             var requiredGooglepermittedGroupsVariable = Environment.GetEnvironmentVariable(permittedGroupsVariable);
-            if (requiredGooglepermittedGroupsVariable is null) throw new Exception($"Cannot resolve {permittedGroupsVariable} environment variable!");
+            if (requiredGooglepermittedGroupsVariable is null) throw new EnvironmentVariableNullException(permittedGroupsVariable);
 
             _requiredGoogleGroups = requiredGooglepermittedGroupsVariable.Split(','); // Note: Env variable must not have spaces after commas
         }
@@ -45,7 +45,7 @@ namespace DeveloperHubAPI.V1.Authorization
             var token = _tokenFactory.Create(_contextWrapper.GetContextRequestHeaders(context.HttpContext));
             if (token is null || !token.Groups.Any(g => _requiredGoogleGroups.Contains(g)))
             {
-                context.Result = new UnauthorizedObjectResult($"User {token?.Name} is not authorized to access this endpoint");
+                context.Result = new UnauthorizedObjectResult($"User {token?.Name} is not authorized to access this endpoint.");
             }
         }
     }

--- a/DeveloperHubAPI/V1/Authorization/AuthorizeByGroups.cs
+++ b/DeveloperHubAPI/V1/Authorization/AuthorizeByGroups.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using Hackney.Core.Http;
+using Hackney.Core.JWT;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace DeveloperHubAPI.V1.Authorization
+{
+    // TODO: Write automated tests & possibly move to shared package once implemented
+    public class AuthorizeByGroups : TypeFilterAttribute
+    {
+        /// <summary>
+        /// Authorise this endpoint using permitted groups
+        /// </summary>
+        /// <param name="permittedGroupsVariable">
+        /// The name of the environment variable that stores the permitted groups for the endpoint
+        /// </param>
+        public AuthorizeByGroups(string permittedGroupsVariable)
+            : base(typeof(TokenGroupsFilter))
+        {
+            Arguments = new object[] { permittedGroupsVariable };
+        }
+    }
+
+    public class TokenGroupsFilter : IAuthorizationFilter
+    {
+        private readonly string[] _requiredGoogleGroups;
+        private readonly ITokenFactory _tokenFactory;
+        private readonly IHttpContextWrapper _contextWrapper;
+
+        public TokenGroupsFilter(IHttpContextWrapper contextWrapper, ITokenFactory tokenFactory, string permittedGroupsVariable)
+        {
+            _contextWrapper = contextWrapper;
+            _tokenFactory = tokenFactory;
+
+            var requiredGooglepermittedGroupsVariable = Environment.GetEnvironmentVariable(permittedGroupsVariable);
+            if (requiredGooglepermittedGroupsVariable is null) throw new Exception($"Cannot resolve {permittedGroupsVariable} environment variable!");
+
+            _requiredGoogleGroups = requiredGooglepermittedGroupsVariable.Split(','); // Note: Env variable must not have spaces after commas
+        }
+
+        public void OnAuthorization(AuthorizationFilterContext context)
+        {
+            var token = _tokenFactory.Create(_contextWrapper.GetContextRequestHeaders(context.HttpContext));
+            if (token is null || !token.Groups.Any(g => _requiredGoogleGroups.Contains(g)))
+            {
+                context.Result = new UnauthorizedObjectResult($"User {token?.Name} is not authorized to access this endpoint");
+            }
+        }
+    }
+}

--- a/DeveloperHubAPI/V1/Authorization/EnvironmentVariableNullException.cs
+++ b/DeveloperHubAPI/V1/Authorization/EnvironmentVariableNullException.cs
@@ -1,0 +1,8 @@
+namespace DeveloperHubAPI.V1.Authorization
+{
+    public class EnvironmentVariableNullException : System.Exception
+    {
+        public EnvironmentVariableNullException(string variableName) : base($"Cannot resolve {variableName} environment variable.") { }
+
+    }
+}

--- a/DeveloperHubAPI/V1/Controllers/DeveloperHubAPIController.cs
+++ b/DeveloperHubAPI/V1/Controllers/DeveloperHubAPIController.cs
@@ -1,3 +1,4 @@
+using DeveloperHubAPI.V1.Authorization;
 using DeveloperHubAPI.V1.Boundary.Request;
 using DeveloperHubAPI.V1.Boundary.Response;
 using DeveloperHubAPI.V1.UseCase.Interfaces;
@@ -5,8 +6,6 @@ using Hackney.Core.Logging;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace DeveloperHubAPI.V1.Controllers
@@ -20,13 +19,15 @@ namespace DeveloperHubAPI.V1.Controllers
         private readonly IGetDeveloperHubByIdUseCase _getDeveloperHubByIdUseCase;
         private readonly IGetApplicationByNameUseCase _getApplicationByNameUseCase;
         private readonly IUpdateApplicationUseCase _updateApplicationUseCase;
-        public DeveloperHubAPIController(IGetDeveloperHubByIdUseCase getDeveloperHubByIdUseCase, IGetApplicationByNameUseCase getApplicationByNameUseCase, IUpdateApplicationUseCase updateApplicationUseCase)
+
+        public DeveloperHubAPIController(IGetDeveloperHubByIdUseCase getDeveloperHubByIdUseCase, IGetApplicationByNameUseCase getApplicationByNameUseCase,
+                                        IUpdateApplicationUseCase updateApplicationUseCase)
         {
             _getDeveloperHubByIdUseCase = getDeveloperHubByIdUseCase;
             _getApplicationByNameUseCase = getApplicationByNameUseCase;
             _updateApplicationUseCase = updateApplicationUseCase;
-        }
 
+        }
 
         /// <summary>
         /// Retrieve all data by ID
@@ -70,6 +71,7 @@ namespace DeveloperHubAPI.V1.Controllers
         [ProducesResponseType(typeof(ApplicationResponse), StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ApplicationResponse), StatusCodes.Status404NotFound)]
         [HttpPatch]
+        [AuthorizeByGroups("googleGroups")]
         [LogCall(LogLevel.Information)]
         [Route("{id}/{applicationName}")]
         public async Task<IActionResult> PatchApplication([FromRoute] ApplicationByNameRequest pathParameters, [FromBody] UpdateApplicationListItem bodyParameters)

--- a/DeveloperHubAPI/V1/Controllers/DeveloperHubAPIController.cs
+++ b/DeveloperHubAPI/V1/Controllers/DeveloperHubAPIController.cs
@@ -72,7 +72,7 @@ namespace DeveloperHubAPI.V1.Controllers
         /// <response code="404">No data found for the specified ID</response>
         [ProducesResponseType(StatusCodes.Status200OK)]
         [HttpDelete]
-        [AuthorizeByGroups("googleGroups")]
+        [AuthorizeByGroups("ALLOWED_GOOGLE_GROUPS")]
         [LogCall(LogLevel.Information)]
         [Route("{id}/{applicationName}")]
         public async Task<IActionResult> DeleteApplication([FromRoute] DeleteApplicationByNameRequest query)
@@ -91,7 +91,7 @@ namespace DeveloperHubAPI.V1.Controllers
         [ProducesResponseType(typeof(ApplicationResponse), StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ApplicationResponse), StatusCodes.Status404NotFound)]
         [HttpPatch]
-        [AuthorizeByGroups("googleGroups")]
+        [AuthorizeByGroups("ALLOWED_GOOGLE_GROUPS")]
         [LogCall(LogLevel.Information)]
         [Route("{id}/{applicationName}")]
         public async Task<IActionResult> PatchApplication([FromRoute] ApplicationByNameRequest pathParameters, [FromBody] UpdateApplicationListItem bodyParameters)

--- a/DeveloperHubAPI/V1/Controllers/DeveloperHubAPIController.cs
+++ b/DeveloperHubAPI/V1/Controllers/DeveloperHubAPIController.cs
@@ -72,6 +72,8 @@ namespace DeveloperHubAPI.V1.Controllers
         /// <response code="404">No data found for the specified ID</response>
         [ProducesResponseType(StatusCodes.Status200OK)]
         [HttpDelete]
+        [AuthorizeByGroups("googleGroups")]
+        [LogCall(LogLevel.Information)]
         [Route("{id}/{applicationName}")]
         public async Task<IActionResult> DeleteApplication([FromRoute] DeleteApplicationByNameRequest query)
         {

--- a/DeveloperHubAPI/serverless.yml
+++ b/DeveloperHubAPI/serverless.yml
@@ -21,6 +21,7 @@ functions:
     handler: DeveloperHubAPI::DeveloperHubAPI.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
     environment:
+      ALLOWED_GOOGLE_GROUPS: ${ssm:/developer-hub/${self:provider.stage}/allowed-google-groups}
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
### *What is the problem we're trying to solve*

We wanted to make it so that only the people with the correct level of authority would have access to the patch and delete functionality based on the google group they are apart of.

### *What changes have we introduced*

- Amended patch E2Es to pass
- Amended the delete endpoint in the controller to have authorisation
- Refactored delete endpoint in controller to have logging
- Amended delete E2Es to incorporate the authorisation process

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
